### PR TITLE
Translation setup tweaks

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Robert Ancell <robert.ancell@canonical.com>
 Build-Depends: debhelper (>= 10),
+               dh-translations,
                libglib2.0-dev,
                libjson-glib-dev,
                libpolkit-gobject-1-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,4 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@
+	dh $@  --with translations

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'ua-daemon', 'c',
+  'ubuntu-advantage-desktop-daemon', 'c',
   version : '1.0',
   license : 'GPL3',
   meson_version : '>= 0.45.1'

--- a/meson.build
+++ b/meson.build
@@ -18,4 +18,5 @@ libexecdir = join_paths(get_option('prefix'), get_option('libexecdir'))
 policy_dir = polkit_gobject_dep.get_pkgconfig_variable('policydir', define_variable: ['prefix', get_option('prefix')])
 po_dir = join_paths(meson.current_source_dir(), 'po')
 
+subdir('po')
 subdir('src')

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,3 @@
 # List of source files which contain translatable strings.
-data/com.canonical.UbuntuAdvantage.policy.in
+src/com.canonical.UbuntuAdvantage.policy.in
 src/main.c

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,1 @@
+i18n.gettext(meson.project_name(), preset: 'glib')


### PR DESCRIPTION
Tweaks to the translation setup. Without the meson changes there is no target to generate the template, after the change we can do

$ meson compile ubuntu-advantage-desktop-daemon-pot

Note that the changeset rename the project in the meson.build for consistency, if you want to stick to ua-daemon then src/meson.build should be updated to use the same GETTEXT_PACKAGE or po/meson.build changed to use 'ua-daemon' as a string instead of meson.project_name()