### PR TITLE
Specify the gettext data_dirs for the polkit files to be translated

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -1,1 +1,1 @@
-i18n.gettext(meson.project_name(), preset: 'glib')
+i18n.gettext(meson.project_name(), preset: 'glib', data_dirs : '.')


### PR DESCRIPTION
The template update currently fails to include the polkit strings on the builders

xgettext: warning: file 'src/com.canonical.UbuntuAdvantage.policy.in' extension 'policy' is unknown; will try C

That's because it needs the files in /usr/share/gettext/its which are provided by policykit-1