### PR TITLE
Fix an error in one of the authorization strings

### DIFF
--- a/src/com.canonical.UbuntuAdvantage.policy.in
+++ b/src/com.canonical.UbuntuAdvantage.policy.in
@@ -17,7 +17,7 @@
   </action>
 
   <action id="com.canonical.UbuntuAdvantage.detach">
-    <description>Attach machine from Ubuntu Advantage</description>
+    <description>Detach machine from Ubuntu Advantage</description>
     <message>Authentication is required to detach this machine from Ubuntu Advantage</message>
     <defaults>
       <allow_any>auth_admin</allow_any>


### PR DESCRIPTION
It was raised up by a translator on https://lists.ubuntu.com/archives/ubuntu-translators/2022-January/007786.html