### PR TITLE
relax the hardening rules to fix livepatch and other services

### DIFF
--- a/src/ubuntu-advantage-desktop-daemon.service.in
+++ b/src/ubuntu-advantage-desktop-daemon.service.in
@@ -9,17 +9,12 @@ ExecStart=@libexecdir@/ubuntu-advantage-desktop-daemon
 Restart=on-failure
 
 MemoryDenyWriteExecute=yes
-NoNewPrivileges=yes
 PrivateDevices=yes
 PrivateTmp=yes
 ProtectProc=invisible
 ProtectControlGroups=yes
-ProtectHome=yes
 ProtectKernelLogs=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes
-ProtectSystem=strict
-ReadWritePaths=/var
-RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes


### PR DESCRIPTION
https://launchpad.net/bugs/1972809

- NoNewPrivileges=yes leads to this error

Livepatch not enabled. Failed running command '/snap/bin/canonical-livepatch status' [exit(1)]. Message: cannot change apparmor hat: Operation not permitted

- ProtectHome=yes leads to this error

Failed running command '/snap/bin/canonical-livepatch status' [exit(1)]. Message: cmd_run.go:1044: WARNING: cannot create user data directory: cannot create snap home dir: mkdir /root/snap: read-only file system

- ProtectSystem=strict

create issues installing packages or enabling the esm repository

- RestrictNamespaces=yes leads to

cannot join mount namespace of pid 1: Operation not permitted