### PR TITLE
Don't use gdbus-codegen --c-generate-autocleanup - it's not available…

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,6 @@ gdbus_src = custom_target(
     '--c-namespace', 'Ua',
     '--generate-c-code', 'ua-ubuntu-advantage-generated',
     '--output-directory', meson.current_build_dir(),
-    '--c-generate-autocleanup', 'all',
     '@INPUT@',
   ]
 )

--- a/src/ua-daemon.c
+++ b/src/ua-daemon.c
@@ -7,6 +7,11 @@
 #include "ua-tool.h"
 #include "ua-ubuntu-advantage-generated.h"
 
+// These are not in the generated code because gdbus-codegen
+// --c-generate-autocleanup is not available in 16.04 LTS.
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(UaUbuntuAdvantageManager, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(UaUbuntuAdvantageService, g_object_unref)
+
 struct _UaDaemon {
   GObject parent_instance;
 


### PR DESCRIPTION
… in 16.04 LTS.