### PR TITLE
ua-tool: Pass the token via a private temporary attach config file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,20 @@ project(
 gnome = import('gnome')
 i18n = import('i18n')
 
-gio_dep = dependency('gio-unix-2.0')
+# We want to target 16.04 for now
+glib_minmax_version = '2.48'
+
+glib_version_def = 'GLIB_VERSION_@0@_@1@'.format(
+  glib_minmax_version.split('.')[0], glib_minmax_version.split('.')[1])
+
+cc = meson.get_compiler('c')
+add_project_arguments(cc.get_supported_arguments([
+    '-DGLIB_VERSION_MIN_REQUIRED=' + glib_version_def,
+    '-DGLIB_VERSION_MAX_ALLOWED=' + glib_version_def,
+  ]),
+  language: 'c')
+
+gio_dep = dependency('gio-unix-2.0', version: '>=' + glib_minmax_version)
 json_glib_dep = dependency('json-glib-1.0')
 polkit_gobject_dep = dependency('polkit-gobject-1')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,7 +23,7 @@ conf.set_quoted('PROJECT_VERSION', meson.project_version())
 configure_file(output: 'config.h',
                configuration: conf)
 
-executable('ubuntu-advantage-desktop-daemon',
+ua_daemon = executable('ubuntu-advantage-desktop-daemon',
            'main.c', 'ua-authorization.c', 'ua-daemon.c', 'ua-service.c', 'ua-status.c', 'ua-status-monitor.c', 'ua-tool.c',
            gdbus_src,
            dependencies: [gio_dep, json_glib_dep, polkit_gobject_dep],

--- a/src/ua-daemon.c
+++ b/src/ua-daemon.c
@@ -381,6 +381,7 @@ static void bus_acquired_cb(GDBusConnection *connection, const gchar *name,
 static void name_lost_cb(GDBusConnection *connection, const gchar *name,
                          gpointer user_data) {
   UaDaemon *self = user_data;
+  g_message("Name '%s' lost", name);
   g_signal_emit(self, signals[SIGNAL_QUIT], 0);
 }
 

--- a/src/ua-tool.c
+++ b/src/ua-tool.c
@@ -2,6 +2,19 @@
 
 #include "ua-tool.h"
 
+typedef struct {
+  char *config_contents;
+  GFile *config_file;
+  GFileIOStream *iostream;
+} AttachData;
+
+static void attach_data_free(AttachData *data) {
+  g_clear_pointer(&data->config_contents, g_free);
+  g_clear_object(&data->config_file);
+  g_clear_object(&data->iostream);
+  g_free(data);
+}
+
 // Wait for [subprocess] to complete, and return an error in [task] if it did
 // not.
 static gboolean wait_finish(GSubprocess *subprocess, GAsyncResult *result,
@@ -34,10 +47,15 @@ static void ua_attach_cb(GObject *object, GAsyncResult *result,
                          gpointer user_data) {
   GSubprocess *subprocess = G_SUBPROCESS(object);
   g_autoptr(GTask) task = G_TASK(user_data);
+  AttachData *attach_data = g_task_get_task_data(task);
+  g_autoptr(GFile) config_file = g_steal_pointer(&attach_data->config_file);
 
   if (wait_finish(subprocess, result, task)) {
     g_task_return_boolean(task, TRUE);
   }
+
+  // We don't really care about of the result of this operation.
+  g_file_delete_async(config_file, G_PRIORITY_DEFAULT, NULL, NULL, NULL);
 }
 
 // Called when 'pro detach' process completes.
@@ -73,21 +91,107 @@ static void ua_disable_cb(GObject *object, GAsyncResult *result,
   }
 }
 
-// Attach this machine to an Ubuntu Advantage subscription.
-void ua_attach(const char *token, GCancellable *cancellable,
-               GAsyncReadyCallback callback, gpointer callback_data) {
-  g_autoptr(GTask) task =
-      g_task_new(NULL, cancellable, callback, callback_data);
-
+// Called when token configuration file if filled.
+static void ua_attach_call_client(GObject *object, GAsyncResult *result,
+                                  gpointer user_data) {
+  GOutputStream *output_stream = G_OUTPUT_STREAM(object);
+  g_autoptr(GTask) task = G_TASK(user_data);
   g_autoptr(GError) error = NULL;
-  g_autoptr(GSubprocess) subprocess = g_subprocess_new(
-      G_SUBPROCESS_FLAGS_STDOUT_PIPE, &error, "pro", "attach", token, NULL);
+
+  if (!g_output_stream_write_all_finish(output_stream, result, NULL, &error)) {
+    g_task_return_error(task, g_steal_pointer(&error));
+    return;
+  }
+
+  // We don't really care about of the result of this operation.
+  g_output_stream_close_async(output_stream, G_PRIORITY_DEFAULT, NULL, NULL,
+                              NULL);
+
+  AttachData *attach_data = g_task_get_task_data(task);
+  g_autofree char *config_file_path = g_file_get_path(attach_data->config_file);
+  g_autoptr(GSubprocess) subprocess =
+      g_subprocess_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE, &error, "pro", "attach",
+                       "--attach-config", config_file_path, NULL);
   if (subprocess == NULL) {
     g_task_return_error(task, g_steal_pointer(&error));
     return;
   }
+
+  GCancellable *cancellable = g_task_get_cancellable(task);
   g_subprocess_wait_async(subprocess, cancellable, ua_attach_cb,
                           g_steal_pointer(&task));
+}
+
+static void write_attach_config_file(GFile *config_file,
+                                     GFileIOStream *iostream, GTask *task) {
+  const char *token = g_task_get_task_data(task);
+  AttachData *attach_data = g_new0(AttachData, 1);
+  // See:
+  // https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/how_to_attach_with_config_file/
+  attach_data->config_contents = g_strdup_printf("token: %s\n", token);
+  attach_data->config_file = g_object_ref(config_file);
+  attach_data->iostream = g_object_ref(iostream);
+
+  g_task_set_task_data(task, attach_data, (GDestroyNotify)attach_data_free);
+
+  GCancellable *cancellable = g_task_get_cancellable(task);
+  GOutputStream *output_stream =
+      g_io_stream_get_output_stream(G_IO_STREAM(iostream));
+  g_output_stream_write_all_async(
+      output_stream, attach_data->config_contents,
+      strlen(attach_data->config_contents), G_PRIORITY_DEFAULT, cancellable,
+      ua_attach_call_client, g_steal_pointer(&task));
+}
+
+#if GLIB_CHECK_VERSION(2, 74, 0)
+// Called when token configuration file is created.
+static void ua_token_file_create_cb(GObject *object, GAsyncResult *result,
+                                    gpointer user_data) {
+  g_autoptr(GTask) task = G_TASK(user_data);
+  g_autoptr(GFileIOStream) iostream = NULL;
+  g_autoptr(GError) error = NULL;
+
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  g_autoptr(GFile) config_file =
+      g_file_new_tmp_finish(result, &iostream, &error);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+  if (!config_file) {
+    g_task_return_error(task, g_steal_pointer(&error));
+    return;
+  }
+
+  write_attach_config_file(config_file, iostream, g_steal_pointer(&task));
+}
+#endif /* GLIB_CHECK_VERSION(2, 74, 0) */
+
+// Attach this machine to an Ubuntu Advantage subscription.
+void ua_attach(const char *token, GCancellable *cancellable,
+               GAsyncReadyCallback callback, gpointer callback_data) {
+  static const char *file_template = "ubuntu-pro-config-XXXXXX.yaml";
+  g_autoptr(GTask) task =
+      g_task_new(NULL, cancellable, callback, callback_data);
+
+  g_task_set_task_data(task, g_strdup(token), g_free);
+
+  // This is safe because the file is going to be owned by the daemon user with
+  // readwrite permissions only from the same user.
+#if GLIB_CHECK_VERSION(2, 74, 0)
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  g_file_new_tmp_async(file_template, G_PRIORITY_DEFAULT, cancellable,
+                       ua_token_file_create_cb, g_steal_pointer(&task));
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#else
+  g_autoptr(GFileIOStream) iostream = NULL;
+  g_autoptr(GFile) config_file = NULL;
+  g_autoptr(GError) error = NULL;
+
+  config_file = g_file_new_tmp(file_template, &iostream, &error);
+  if (config_file == NULL) {
+    g_task_return_error(task, g_steal_pointer(&error));
+    return;
+  }
+  write_attach_config_file(config_file, iostream, g_steal_pointer(&task));
+#endif
 }
 
 // Complete request started with ua_attach().

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -34,13 +34,15 @@ test_disable_service = executable('test-disable-service',
                                   'test-daemon.c',
                                   dependencies: [gio_dep, json_glib_dep])
 
-executable('pro',
-           'mock-ua.c',
-           dependencies: [gio_dep, json_glib_dep])
+pro = executable('pro',
+                 'mock-ua.c',
+                 dependencies: [gio_dep, json_glib_dep])
 
-test('Attach', test_attach)
-test('Attach - Invalid Token', test_attach_invalid_token)
-test('Detach', test_detach)
-test('List Services', test_list_services)
-test('Enable Service', test_enable_service)
-test('Disable Service', test_disable_service)
+tests_deps = [ua_daemon, pro]
+
+test('Attach', test_attach, depends: tests_deps)
+test('Attach - Invalid Token', test_attach_invalid_token, depends: tests_deps)
+test('Detach', test_detach, depends: tests_deps)
+test('List Services', test_list_services, depends: tests_deps)
+test('Enable Service', test_enable_service, depends: tests_deps)
+test('Disable Service', test_disable_service, depends: tests_deps)

--- a/tests/mock-ua.c
+++ b/tests/mock-ua.c
@@ -2,6 +2,7 @@
 #include <json-glib/json-glib.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 static JsonObject *get_status() {
   const gchar *status_file = getenv("MOCK_UA_STATUS_FILE");
@@ -75,6 +76,11 @@ static int attach(int argc, char **argv) {
       g_critical("Cannot open config file %s: %s", config_file, error->message);
       return EXIT_FAILURE;
     }
+
+    // Ensure the file is only readable by the current user.
+    struct stat statbuf;
+    g_assert_cmpint(stat(config_file, &statbuf), ==, 0);
+    g_assert_cmpint(statbuf.st_mode, ==, S_IFREG | 0600);
 
     yaml_regex = g_regex_new("^token:\\s*(\\w+)$",
                              G_REGEX_OPTIMIZE | G_REGEX_MULTILINE, 0, NULL);

--- a/tests/test-attach.c
+++ b/tests/test-attach.c
@@ -42,10 +42,12 @@ static void get_attached_cb(GObject *object, GAsyncResult *result,
                          "/com/canonical/UbuntuAdvantage/Manager",
                          "com.canonical.UbuntuAdvantage.Manager", "Attach",
                          g_variant_new("(s)", "1234"), G_VARIANT_TYPE("()"),
-                         G_DBUS_CALL_FLAGS_NONE, -1, NULL, attach_cb, NULL);
+                         G_DBUS_CALL_FLAGS_NONE, -1, NULL, attach_cb, &error);
+  g_assert_no_error(error);
 }
 
 static void daemon_ready_cb(GDBusConnection *connection) {
+  g_autoptr(GError) error = NULL;
   g_dbus_connection_call(connection, "com.canonical.UbuntuAdvantage",
                          "/com/canonical/UbuntuAdvantage/Manager",
                          "org.freedesktop.DBus.Properties", "Get",
@@ -53,7 +55,8 @@ static void daemon_ready_cb(GDBusConnection *connection) {
                                        "com.canonical.UbuntuAdvantage.Manager",
                                        "Attached"),
                          G_VARIANT_TYPE("(v)"), G_DBUS_CALL_FLAGS_NONE, -1,
-                         NULL, get_attached_cb, NULL);
+                         NULL, get_attached_cb, &error);
+  g_assert_no_error(error);
 }
 
 static void attached_changed_cb(gboolean attached) {

--- a/tests/test-daemon.c
+++ b/tests/test-daemon.c
@@ -265,7 +265,8 @@ int test_daemon_run(
   json_builder_end_object(builder);
 
   g_autoptr(JsonGenerator) generator = json_generator_new();
-  json_generator_set_root(generator, json_builder_get_root(builder));
+  g_autoptr(JsonNode) root = json_builder_get_root(builder);
+  json_generator_set_root(generator, root);
   g_autofree gchar *status_json = json_generator_to_data(generator, NULL);
 
   if (!g_file_set_contents(status_path, status_json, -1, &error)) {


### PR DESCRIPTION
    We're currently calling the pro client with attach parameter in plain
    text, but this leads to leaking such private information to any user in
    the system (via simple ps).
    
    So use a temporary file instead. This is safe because it's created by
    default with -rw------- only permissions, so it won't be readable by
    anyone else.
    
    We could use an extra layer of protection saving it in the runtime
    directory, but this is already enough.
    
    LP: #2068944

UDENG-3188
